### PR TITLE
Run golangci-lint and fix some issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+# Config file for golangci-lint.
+version: 2
 # Options for analysis running.
 run:
   # Default concurrency is a available CPU number.
@@ -14,7 +16,7 @@ output:
   # Output styling.
   # e.g. colored-line-number, line-number, json, tab, checkstyle, code-climate.
   # Default is colored-line-number.
-  formats: colored-line-number
+  format: colored-line-number
   # Print lines of code with issue, default is true.
   print-issued-lines: true
   # Print linter name in the end of issue text, default is true.
@@ -81,7 +83,6 @@ linters:
     # Go linter to check the errors handling expressions.
     - err113
     # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
-    - goimports
     # An analyzer to detect magic numbers.
     - mnd
     # Checks that printf-like functions are named with f at the end.
@@ -89,7 +90,6 @@ linters:
     # Inspects source code for security problems.
     - gosec
     # Linter for Go source code that specializes in simplifying code.
-    - gosimple
     # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string.
     - govet
     # An analyzer to analyze expression groups.
@@ -145,11 +145,9 @@ linters:
     # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
     - staticcheck
     # Stylecheck is a replacement for golint.
-    - stylecheck
     # The tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
     - usetesting
     # Like the front-end of a Go compiler, parses and type-checks Go code.
-    - typecheck
     # The thelper detects Go test helpers without t.Helper() call and checks the consistency of test helpers.
     - thelper
     # Remove unnecessary type conversions.

--- a/internal/repo/redis/migrations/userpools_to_set.go
+++ b/internal/repo/redis/migrations/userpools_to_set.go
@@ -32,6 +32,9 @@ func (u UserPoolToSet) Up(ctx context.Context, tr *redis.Tx) error {
 			userPools := make([]string, 0)
 
 			data, err := tr.Get(ctx, key).Bytes()
+			if err != nil {
+				return err
+			}
 
 			if data != nil {
 				if err = json.Unmarshal(data, &userPools); err != nil {

--- a/internal/services/estimator/formula.go
+++ b/internal/services/estimator/formula.go
@@ -11,12 +11,6 @@ const (
 	AlkalinityHigh = 120
 )
 
-var chlorineLowByUsage = map[common.UsageType]float64{
-	common.UsageTypePrivate: 1,
-	common.UsageTypePublic:  3,
-	common.UsageTypeHoliday: 1,
-}
-
 var chlorineHighByUsage = map[common.UsageType]float64{
 	common.UsageTypePrivate: 3.0,
 	common.UsageTypePublic:  5,


### PR DESCRIPTION
## Summary
- update golangci-lint configuration for v2 format
- fix ineffassign by handling error in redis migration
- drop unused chlorineLowByUsage map

## Testing
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6849ce407dc88325b13c4efefe34454a